### PR TITLE
8/intermittant sell error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 
 build
 screenshots
+useful-screenshots

--- a/src/functions/prontoSellMagCommentScript.ts
+++ b/src/functions/prontoSellMagCommentScript.ts
@@ -59,10 +59,8 @@ export const prontoSellMagCommentScript = async () => {
   // try to run on 10 orders only
   const smallArray = orderDetails.slice(0, 4);
 
-  console.log(smallArray);
-
   const orderDetailsAfterProntoSelling = await runAsyncFuncInSeries(
-    smallArray,
+    orderDetails,
     prontoPage,
     sellSingleOrder,
   );

--- a/src/functions/sellSingleOrder.ts
+++ b/src/functions/sellSingleOrder.ts
@@ -27,8 +27,10 @@ export default async function sellSingleOrder(
   await prontoPage.waitForNetworkIdle();
   await waitTillHTMLRendered(prontoPage);
 
-  // be aware: below selector fails intermittently rarely. is there a better selector i could wait for?
-  // why is it failing?
+  // be aware: below selector fails intermittently rarely. the cause is screen navigating to the wrong place (clicking on the wrong thing)
+  //  i added a wait for dom render at the end of this script so that the screen should be 'fresh' and ready to start process again.
+
+  //ps there is a loader div that has a class of main-loader, and a class of visible when the page is loading, but it's not there for moving between header and esc.
 
   const screenInputFail = await prontoPage.content();
   await saveContent(prontoPage, screenInputFail, "screenInputFail");
@@ -75,6 +77,7 @@ export default async function sellSingleOrder(
 
   console.log("sell single in pronto finished for", order);
   await prontoPage.keyboard.press("Escape");
+  await waitTillHTMLRendered(prontoPage);
   await prontoPage.waitForNetworkIdle();
 
   return {


### PR DESCRIPTION
added a wait for DOM at the end of the function so that the page is 'fresh' and ready to begin script again.

i think the cause of the bug was hitting escape, page is doing an enter from top animation. and im assuming that the click goes to the wrong place? 

not 100% sure